### PR TITLE
Generic integration plugin for sites with TMetric support

### DIFF
--- a/src/in-page-scripts/integrations/generic.ts
+++ b/src/in-page-scripts/integrations/generic.ts
@@ -1,0 +1,37 @@
+﻿class Generic implements WebToolIntegration {
+
+    showIssueId = true;
+
+    observeMutations = true;
+
+    issueElementSelector = '.tmetric-button';
+
+    match(source: Source): boolean {
+        return !!$$('.tmetric-button');
+    }
+
+    render(issueElement: HTMLElement, linkElement: HTMLElement) {
+        issueElement.appendChild(linkElement);
+    }
+
+    getIssue(issueElement: HTMLElement, source: Source): WebToolIssue {
+        let issueId = issueElement.getAttribute('data-issue-id');
+        let issueName = issueElement.getAttribute('data-issue-name');
+        let serviceUrl = issueElement.getAttribute('data-service-url');
+        let issueUrl = issueElement.getAttribute('data-issue-url');
+        let projectName = issueElement.getAttribute('data-project-name');
+        let tagNames = issueElement.getAttribute('data-tag-names').split(',');
+
+        return {
+            issueId,
+            issueName,
+            issueUrl,
+            projectName,
+            serviceUrl,
+            serviceType: 'Generic',
+            tagNames
+        };
+    }
+}
+
+IntegrationService.register(new Generic());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -96,6 +96,7 @@
                 "in-page-scripts/integrations/bugzilla.js",
                 "in-page-scripts/integrations/doitIm.js",
                 "in-page-scripts/integrations/freshdesk.js",
+                "in-page-scripts/integrations/generic.js",
                 "in-page-scripts/integrations/gitHub.js",
                 "in-page-scripts/integrations/gitLab.js",
                 "in-page-scripts/integrations/google-calendar.js",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -33,6 +33,7 @@
         "in-page-scripts/integrations/bugzilla.ts",
         "in-page-scripts/integrations/doitIm.ts",
         "in-page-scripts/integrations/freshdesk.ts",
+        "in-page-scripts/integrations/generic.ts",
         "in-page-scripts/integrations/gitHub.ts",
         "in-page-scripts/integrations/gitLab.ts",
         "in-page-scripts/integrations/google-calendar.ts",


### PR DESCRIPTION
Binds to any page looking for ".tmetric-button". If found takes issue attributes from element's data attributes.

This way we can integrate TMetric to our internal tools that could never be supported using "standard" plugins - internal tools, internal domains ....