### PR TITLE
Fix GitHub integration

### DIFF
--- a/src/in-page-scripts/integrations/gitHub.ts
+++ b/src/in-page-scripts/integrations/gitHub.ts
@@ -24,7 +24,7 @@
             return;
         }
 
-        let projectName = $$.try('.repohead-details-container > h1 > strong > a').textContent;
+        let projectName = $$.try('[itemprop=name]').textContent;
 
         // https://github.com/NAMESPACE/PROJECT/issues/NUMBER
         // https://github.com/NAMESPACE/PROJECT/pull/NUMBER


### PR DESCRIPTION
Looks like they've changed the markup in new layout (feature preview).
`[itemprop=name]` is less likely to change in future since it's semantic.
Can't switch back to test if this works for the old layout.