### PR TITLE
allow openproject URLs with any TLD

### DIFF
--- a/src/in-page-scripts/integrations/openProject.ts
+++ b/src/in-page-scripts/integrations/openProject.ts
@@ -2,7 +2,7 @@ class OpenProject implements WebToolIntegration {
 
     showIssueId = true;
 
-    matchUrl = /(https:\/\/.+\.openproject\.com).*\/work_packages\/\D*(\d+)/;
+    matchUrl = /(https:\/\/.+\.openproject\..*).*\/work_packages\/\D*(\d+)/;
 
     observeMutations = true;
 


### PR DESCRIPTION
an openproject that runs under any other TLD than .com would not work otherwise.
It would be even better if that could be taken from the settings of the addon, but I haven't looked into it so deeply to know how to do that