### PR TITLE
TFS / Azure DevOps support for custom project name field

### DIFF
--- a/src/in-page-scripts/integrations/tfs.ts
+++ b/src/in-page-scripts/integrations/tfs.ts
@@ -70,8 +70,9 @@ class TfsIntegration implements WebToolIntegration {
         let serviceType = 'TFS';
 
         let itemView = $$.visible('.work-item-view, .work-item-form-subheader', issueElement);
-        let projectInput = itemView && $$('input[aria-label="Area Path"], input[id=__bolt--Area-input]', itemView) // new layout
-            || $$('.work-item-form-areaIteration input', issueElement) // old layout
+        let projectInput = itemView && $$('input[aria-label="projectName"]', itemView) // custom layout
+                || $$('input[aria-label="Area Path"], input[id=__bolt--Area-input]', itemView) // new layout
+                || $$('.work-item-form-areaIteration input', issueElement) // old layout
         let projectName = projectInput && (<HTMLInputElement>projectInput).value;
 
         return { issueId, issueName, projectName, serviceType, serviceUrl, issueUrl, tagNames };


### PR DESCRIPTION
Adds support for a custom project name instead of using Area for the project name. If the custom field cannot be found, the project name defaults back to Area.