### PR TITLE
Fix Asana integration

### DIFF
--- a/src/in-page-scripts/integrations/asana.ts
+++ b/src/in-page-scripts/integrations/asana.ts
@@ -95,6 +95,7 @@ class Asana implements WebToolIntegration {
         }
 
         const projectName =
+            $$.try('.TaskProjectTokenPill-name').textContent || // task project name for latest Asana
             $$.try('.TaskProjectToken-projectName').textContent || // task project token
             $$.try('.TaskProjectPill-projectName, .TaskProjectToken-potTokenizerPill').textContent || // task project pill
             $$.try('.TaskAncestry-ancestorProject').textContent; // subtask project


### PR DESCRIPTION
On the latest Asana app you couldn't start timer automatically even if the project name was there (it had to be always done manually). There is a fix that will take correct project name. Added as 'or' because there is at least one user that did't have this problem. 