### PR TITLE
Correct Bitbucket toolbar query selector

### DIFF
--- a/src/in-page-scripts/integrations/bitbucket.ts
+++ b/src/in-page-scripts/integrations/bitbucket.ts
@@ -16,6 +16,7 @@ class Bitbucket implements WebToolIntegration {
         const toolbar =
             $$('#issue-header .issue-toolbar') || // issue actions
             $$('main [data-qa=pr-header-actions-drop-down-menu-styles]')?.parentElement || // pull request actions
+            $$('[role="main"] [data-qa=pr-header-actions-drop-down-menu-styles]')?.parentElement || // pull request actions
             $$('button[data-testid="commit-more-button--trigger"]')?.parentElement; // commit actions
         if (toolbar) {
             Object.assign(linkElement.style, {


### PR DESCRIPTION
Bitbucket has apparently changed their HTML structure on the Pull Request page, because it seems it doesn't have a `<MAIN>` element any more, but a `<DIV role="main">`. Therefore The "Start timer" does not appear on the PR page.

It may be, that Bitbucket has _old_ and _new_ interface, so this PR kept both selectors, so whichever will match, will return the toolbar where the TMetric "Start timer" should be inserted.