### PR TITLE
Support ClickUp whitelabel custom subdomains

### DIFF
--- a/src/background/webToolDescriptions.ts
+++ b/src/background/webToolDescriptions.ts
@@ -95,6 +95,7 @@ const getWebToolDescriptions = function () {
             serviceName: 'ClickUp',
             icon: 'clickup.svg',
             origins: ['https://app.clickup.com/*'],
+            hasAdditionalOrigins: true,
             scripts: {
                 js: ['in-page-scripts/integrations/clickup.js']
             }

--- a/src/in-page-scripts/integrations/clickup.ts
+++ b/src/in-page-scripts/integrations/clickup.ts
@@ -2,7 +2,7 @@ class Clickup implements WebToolIntegration {
 
     showIssueId = false;
 
-    matchUrl = '*://app.clickup.com';
+    matchUrl = '*://*.clickup.com';
 
     issueElementSelector = [
         '.cu-checklist-item__row', // v3 v4 check list item


### PR DESCRIPTION
## Problem

ClickUp workspaces with the whitelabel feature use a custom subdomain (e.g. `mycompany.clickup.com`) instead of `app.clickup.com`. The TMetric ClickUp integration only matches `app.clickup.com`, so the timer button does not appear on whitelabel workspaces.

## Changes

- **`src/in-page-scripts/integrations/clickup.ts`** — Widen `matchUrl` from `*://app.clickup.com` to `*://*.clickup.com` so the integration activates on any ClickUp subdomain.

- **`src/background/webToolDescriptions.ts`** — Add `hasAdditionalOrigins: true` to the ClickUp entry so users with custom subdomains can add them via Settings > Integrations > ClickUp > Edit. This is consistent with how Jira, GitLab, Salesforce, and other integrations handle self-hosted/custom domains.

Default `origins` stays as `['https://app.clickup.com/*']` so the initial permission request remains narrow.

## Testing

1. Load the built extension as unpacked in Chrome
2. Enable the ClickUp integration
3. Navigate to a ClickUp task on `app.clickup.com` — timer button appears (no regression)
4. Click Edit on the ClickUp integration, add a custom subdomain URL
5. Navigate to the custom subdomain — timer button now appears